### PR TITLE
feat: Implement Argon2id hashing for secure PIN storage and retrieval

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
+  cryptography:
+    dependency: "direct main"
+    description:
+      name: cryptography
+      sha256: d146b76d33d94548cf035233fbc2f4338c1242fa119013bead807d033fc4ae05
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,6 +69,7 @@ dependencies:
   
   # Markdown rendering
   flutter_markdown: ^0.7.7+1
+  cryptography: ^2.7.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request updates the PIN security implementation in `SecurityService` to use Argon2id hashing with a random salt for improved security, replacing the previous SHA-256 approach. It also ensures proper storage and verification of both the hash and salt, and updates dependencies accordingly.

**Security improvements:**

* Switched PIN hashing from SHA-256 to Argon2id with a randomly generated 16-byte salt, enhancing resistance against brute-force and rainbow table attacks (`lib/services/security_service.dart`).
* Modified PIN setup to store both the Argon2id hash and its associated salt in `SharedPreferences` (`lib/services/security_service.dart`).
* Updated PIN verification logic to use the stored salt for hash derivation and comparison, ensuring correct authentication with the new scheme (`lib/services/security_service.dart`).
* Changed `isPinSetup()` to check for both hash and salt presence, guaranteeing proper PIN initialization (`lib/services/security_service.dart`).
* Ensured both hash and salt are removed when clearing security data (`lib/services/security_service.dart`).

**Dependency updates:**

* Added the `cryptography` package to `pubspec.yaml` to support Argon2id hashing.