### PR TITLE
feat: Add Monad Testnet to predefined networks

### DIFF
--- a/lib/services/network_service.dart
+++ b/lib/services/network_service.dart
@@ -70,6 +70,19 @@ class NetworkService {
       iconUrl: 'https://avatars.githubusercontent.com/u/113091135',
     ),
 
+    // Monad Testnet
+    const NetworkModel(
+      id: 'monad-testnet',
+      name: 'Monad Testnet',
+      rpcUrl: 'https://rpc.ankr.com/monad_testnet',
+      chainId: 10143,
+      currencySymbol: 'MON',
+      blockExplorerUrl: 'https://testnet.monadexplorer.com/',
+      isTestnet: true,
+      iconPath: 'assets/icons/monad.png',
+      iconUrl: 'https://avatars.githubusercontent.com/u/191391794?s=200&v=4'
+    ),
+
   ];
 
   // Get all available networks (predefined + custom)


### PR DESCRIPTION
This pull request adds support for the Monad Testnet to the list of available networks in the `NetworkService` class. This allows users to interact with the Monad Testnet, including accessing its RPC endpoint, block explorer, and using its native currency symbol.

New network support:

* Added a new `NetworkModel` entry for Monad Testnet, including its RPC URL, chain ID, block explorer URL, currency symbol, and icons.